### PR TITLE
Fix input override in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,6 @@ git clone https://github.com/lboklin/nixified-cfg
 cd nixified-cfg
 # make whatever changes you want to `cfg.comfyui` in ./flake.nix
 # then pass it in when calling a nixified-ai package:
-nix {build,run} github:lboklin/nixified-ai#comfyui-{amd,nvidia} --override-input cfg .
+nix {build,run} github:lboklin/nixified-ai#comfyui-{amd,nvidia} --override-input nixified-cfg .
 ```
 


### PR DESCRIPTION
Using the command as is leads to the input override having no effect. So as per the `flake.nix` and your comments in [nixified-ai/flake #94](https://github.com/nixified-ai/flake/pull/94) the input override should be `nixified-cfg`.