### PR TITLE
Fix examples in collection.nix

### DIFF
--- a/comfyui/models/collection.nix
+++ b/comfyui/models/collection.nix
@@ -5,7 +5,7 @@
 {
   checkpoints = {
     # # https://civitai.com/models/112902/dreamshaper-xl
-    # dreamshaper-xl-fp16 = (fetchModel {
+    # dreamshaper-xl-fp16 = ({
     #   url = "https://civitai.com/api/download/models/351306";
     #   format = "safetensors";
     #   sha256 = "sha256-RJazbUi/18/k5dvONIXbVnvO+ivvcjjSkNvUVhISUIM=";
@@ -16,7 +16,7 @@
   configs = {
     # # https://huggingface.co/lllyasviel/ControlNet-v1-1
     # # See also the accompanying file in `controlnet`.
-    # controlnet-v1_1_fe-sd15-tile = (fetchModel {
+    # controlnet-v1_1_fe-sd15-tile = ({
     #   format = "yaml";
     #   url = "https://huggingface.co/lllyasviel/ControlNet-v1-1/raw/main/control_v11f1e_sd15_tile.yaml";
     #   sha256 = "sha256-OeEzjEFDYYrbF2BPlsOj90DBq10VV9cbBE8DB6CmrbQ=";
@@ -25,7 +25,7 @@
   controlnet = {
     # # https://huggingface.co/lllyasviel/ControlNet-v1-1
     # # See also the accompanying file in `configs`.
-    # controlnet-v1_1_f1e-sd15-tile = (fetchModel {
+    # controlnet-v1_1_f1e-sd15-tile = ({
     #   format = "pth";
     #   url = "https://huggingface.co/lllyasviel/ControlNet-v1-1/blob/main/control_v11f1e_sd15_tile.pth";
     #   sha256 = "sha256-49icVoVc/i6gxOjLRcIpthTxjfwWjlxTx2BjraX4/mM=";


### PR DESCRIPTION
Attempting to use the example given in the `collection.nix` file results in the following error. Removing the `fetchModel` calls, fixes this. 

```nix
error:
       … while calling the 'derivationStrict' builtin

         at /builtin/derivation.nix:9:12: (source not available)

       … while evaluating derivation 'comfyui-unstable-2024-04-15'
         whose name attribute is located at /nix/store/rbkcv82pwkdfksh3qq3v5w0ha1nlzm84-source/pkgs/stdenv/generic/make-derivation.nix:331:7

       … while evaluating attribute 'installPhase' of derivation 'comfyui-unstable-2024-04-15'

         at /nix/store/dx5728k20b0gw7dnm0y4907a09pz9cwh-source/projects/comfyui/package.nix:84:3:

           83|
           84|   installPhase = ''
             |   ^
           85|     runHook preInstall

       (stack trace truncated; use '--show-trace' to show the full trace)

       error: undefined variable 'fetchModel'

       at /nix/store/dvi353nkzyycqsisad2fj5cfjl69f29z-source/comfyui/models/collection.nix:8:28:

            7|     # # https://civitai.com/models/112902/dreamshaper-xl
            8|     dreamshaper-xl-fp16 = (fetchModel {
             |                            ^
            9|       url = "https://civitai.com/api/download/models/351306";
```